### PR TITLE
Add payment to mock order

### DIFF
--- a/Service/PreHandlers/SkipItems.php
+++ b/Service/PreHandlers/SkipItems.php
@@ -64,6 +64,7 @@ class SkipItems implements RecalculationPreHandlerInterface
         //Create mock Order
         $orderSkippedLess = OrderMockBuilder::getNewOrderInstance(0, 0, 0);
         $orderSkippedLess->setData($entity->getData());
+        $orderSkippedLess->setPayment($entity->getPayment());
         $orderSkippedLess->setSubtotalInclTax($newSubTotalInclTax);
         $orderSkippedLess->setGrandTotal($newGrandTotal);
         $orderSkippedLess->setDiscountAmount($newDiscountAmount);


### PR DESCRIPTION
Если принудительно у заказа не вызвать  $order->getPayment(), то в _data не будет payment . И в мок объект не будет информация об оплате. По этому принудительно отправляем информацию об обплате.